### PR TITLE
fix(layout): correct bootstrap javascript SRI hash

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -91,7 +91,7 @@
 
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-YvpcrYf0tY3lHB60NNkmxc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
         crossorigin="anonymous"></script>
 </body>
 


### PR DESCRIPTION
Fixes a typo in the SRI integrity hash for the Bootstrap JS bundle that was preventing execution of interactive components like the admin dropdown menu.