### PR TITLE
Fix: Email Sender Configuration

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -121,6 +121,7 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # Email settings
 vars().update(env.email_url())
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL")
 
 # Default primary key field type
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"


### PR DESCRIPTION
Ensures that DEFAULT_FROM_EMAIL is correctly read from environment variables to avoid SMTP rejections.