### PR TITLE
Security/Config: Hardcodierte Werte aus settings.py in .env auslagern

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -37,7 +37,7 @@ ALLOWED_HOSTS = env("ALLOWED_HOSTS")
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # Erlaube der Domain CSRF-Requests (wichtig für Logins/Formulare)
-CSRF_TRUSTED_ORIGINS = ["https://schul-ag.schwarzpost.de"]
+CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=["https://schul-ag.schwarzpost.de"])
 
 # Application definition
 INSTALLED_APPS = [


### PR DESCRIPTION
Fixes #45. Moved CSRF_TRUSTED_ORIGINS to .env. Note: Local .env should be updated to include 'CSRF_TRUSTED_ORIGINS=https://schul-ag.schwarzpost.de' (already updated in your workspace).