### PR TITLE
Deploy/Doc: Env Variablen in CI/CD und README vervollständigen

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -102,7 +102,9 @@ jobs:
               echo "SECRET_KEY=${{ secrets.SECRET_KEY }}" >> .env
             fi
             
-            # Ensure SMTP variables are in .env
+            # Ensure variables are in .env
+            grep -q "^CSRF_TRUSTED_ORIGINS=" .env || echo "CSRF_TRUSTED_ORIGINS=${{ secrets.CSRF_TRUSTED_ORIGINS }}" >> .env
+            grep -q "^ALLOWED_HOSTS=" .env || echo "ALLOWED_HOSTS=${{ secrets.ALLOWED_HOSTS }}" >> .env
             grep -q "^SMTP_USER=" .env || echo "SMTP_USER=${{ secrets.SMTP_USER }}" >> .env
             grep -q "^SMTP_PASSWORD=" .env || echo "SMTP_PASSWORD=${{ secrets.SMTP_PASSWORD }}" >> .env
             grep -q "^SMTP_HOST=" .env || echo "SMTP_HOST=${{ secrets.SMTP_HOST }}" >> .env

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Damit das Deployment und der E-Mail-Versand funktionieren, müssen im GitHub Rep
 | `SECRET_KEY` | Ein sicherer Django Secret Key |
 | `POSTGRES_PASSWORD` | Passwort für die PostgreSQL Datenbank |
 | `ALLOWED_HOSTS` | Kommagetrennte Liste der Domains, z.B. `schul-ag.schwarzpost.de,schul-ag.foerderverein-sgs-gechingen.de` |
+| `CSRF_TRUSTED_ORIGINS` | Kommagetrennte Liste der vertrauenswürdigen Origins, z.B. `https://schul-ag.schwarzpost.de` |
 | `SMTP_HOST` | Host für Resend: `smtp.resend.com` |
 | `SMTP_USER` | Der Wert `resend` |
 | `SMTP_PASSWORD` | Dein Resend API-Key (beginnt mit `re_...`) |


### PR DESCRIPTION
Addressing user requirement: all needed env variables are now filled in the deploy job from GitHub Secrets and documented in the README.